### PR TITLE
Fix the download failing part-way through by ensuring request content is within the retry policy

### DIFF
--- a/src/HaveIBeenPwned.PwnedPasswords.Downloader/Program.cs
+++ b/src/HaveIBeenPwned.PwnedPasswords.Downloader/Program.cs
@@ -205,11 +205,7 @@ internal sealed class PwnedPasswordsDownloader : Command<PwnedPasswordsDownloade
             requestUri += "?mode=ntlm";
         }
 
-        HttpResponseMessage response = await _policy.ExecuteAsync(() =>
-        {
-            using var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
-            return _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
-        }).ConfigureAwait(false);
+        HttpResponseMessage response = await _policy.ExecuteAsync(() => _httpClient.GetAsync(requestUri)).ConfigureAwait(false);
         Stream content = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
         Interlocked.Add(ref _statistics.CloudflareRequestTimeTotal, cloudflareTimer.ElapsedMilliseconds);
         Interlocked.Increment(ref _statistics.CloudflareRequests);


### PR DESCRIPTION
Fixes #16

Removes the `HttpCompletionOption.ResponseHeadersRead` and replaces the http call with `HttpClient.GetAsync()` which defaults to `HttpCompletionOption.ResponseContentRead`, so the content is read while within the retry policy.
