### PR TITLE
Add --max-retries option and custom retry logic

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,28 @@
+# Copilot instructions for PwnedPasswordsDownloader
+
+## Build, test, and lint commands
+
+- Primary validation command: `dotnet pack .\src\HaveIBeenPwned.PwnedPasswords.Downloader\HaveIBeenPwned.PwnedPasswords.Downloader.csproj --configuration Release`
+- Local CLI smoke test: `dotnet run --project .\src\HaveIBeenPwned.PwnedPasswords.Downloader\HaveIBeenPwned.PwnedPasswords.Downloader.csproj --framework net9.0 -- --help`
+- The project multi-targets `net8.0` and `net9.0`, so `dotnet run` must include `--framework net8.0` or `--framework net9.0`.
+- There is currently no test project in the repository, so there is no full-suite or single-test command yet.
+- There is no repo-specific lint command configured; follow `src\.editorconfig` and use the normal .NET build/pack output as the main validation signal.
+
+## High-level architecture
+
+- This repository is a single packaged .NET CLI tool. The only product project is `src\HaveIBeenPwned.PwnedPasswords.Downloader\HaveIBeenPwned.PwnedPasswords.Downloader.csproj`, and CI validates it by packing the tool rather than building a larger solution graph.
+- `Program.cs` contains nearly all runtime behavior: it bootstraps a generic host, wires an `HttpClient` named `PwnedPasswords`, and runs a single Spectre.Console command class, `PwnedPasswordsDownloader`.
+- The downloader always iterates the full Pwned Passwords range space (`0` through `1024 * 1024 - 1`). `GetHashRange` converts each integer to the 5-character range prefix used by the HIBP range API, and single-file output reconstructs full hashes by prepending that prefix to every returned suffix line.
+- Networking is centralized around the named `HttpClient` plus a Polly resilience pipeline. Requests go to `https://api.pwnedpasswords.com/range/`, use HTTP/2 when available, retry failures up to 10 times, and track Cloudflare cache-hit metrics in `Statistics`.
+- Output has two distinct write paths. `ProcessRanges` either:
+  - streams all ranges through a bounded `Channel<Task<Stream>>` into one `outputFile.txt`, preserving range order, or
+  - downloads each range directly to its own `xxxxx.txt` file with `Parallel.ForEachAsync`.
+- `Helpers.CopyFrom` is the custom high-throughput file-writing primitive for per-range files. It copies the HTTP response stream into a pooled `Pipe` and writes buffers with `RandomAccess.WriteAsync` on a `SafeFileHandle`; reuse that path if you change direct-to-file downloads.
+
+## Key conventions
+
+- Most logic lives in `Program.cs`, including the command settings, downloader implementation, host registration, and DI bridge types. Do not assume this repo follows a many-files-per-type layout.
+- User-facing behavior is intentionally surfaced through Spectre.Console output instead of logging providers. `Program.cs` clears default host logging and reports retries, failures, progress, and final statistics through `AnsiConsole`.
+- Existing output safety checks are part of the command contract: single-file mode refuses to overwrite `outputFile.txt` unless `-o` is set, and directory mode refuses to write into a non-empty directory unless `-o` is set.
+- Keep the packaging layout intact when editing the project file: the NuGet tool package embeds the repository `README.md` and `.github\images\hibp.png`, and the command name is `haveibeenpwned-downloader`.
+- Follow `src\.editorconfig` conventions when editing C#: explicit types are preferred over `var` unless the type is obvious, private/internal fields use `_camelCase`, private/internal static fields use `s_` prefixes, and braces stay on new lines.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org
 |-------------|---------------|-------------|
 | -s/--single | true | Determines whether to download hashes to a single file or as individual .txt files into another directory |
 | -p/--parallelism | Same as `Environment.ProcessorCount` | Determines how many hashes to download at a time |
+| --max-retries | Unlimited | Determines how many times each prefix is retried after a failure. Omit for unlimited retries, or pass `0` to disable retries. Retry delays increase per prefix up to 10 seconds. |
 | -o/--overwrite | false | Determines if output files should be overwritten or not |
 | -n | (none) | When set, the downloader fetches NTLM hashes instead of SHA1 |
 
@@ -66,3 +67,5 @@ dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org
 `haveibeenpwned-downloader.exe hashes -s false -p 64`
 ## Download all hashes to a single txt file called `pwnedpasswords.txt` using 64 threads, overwriting the file if it already exists
 `haveibeenpwned-downloader.exe pwnedpasswords -o -p 64`
+## Download all hashes with at most 5 retries per prefix
+`haveibeenpwned-downloader.exe pwnedpasswords --max-retries 5`

--- a/src/HaveIBeenPwned.PwnedPasswords.Downloader/Helpers.cs
+++ b/src/HaveIBeenPwned.PwnedPasswords.Downloader/Helpers.cs
@@ -31,23 +31,22 @@ namespace HaveIBeenPwned.PwnedPasswords
             }
         }
 
-        internal static async Task CopyFrom<T>(this SafeFileHandle handle, T stream, int offset = 0) where T : Stream
+        internal static async Task CopyFrom<T>(this SafeFileHandle handle, T stream, int offset = 0, CancellationToken cancellationToken = default) where T : Stream
         {
             Pipe pipe = GetPipe();
-            Task copyTask = stream.CopyToAsync(pipe.Writer).ContinueWith(CompleteWriter, pipe.Writer).Unwrap();
+            Task copyTask = stream.CopyToAsync(pipe.Writer, cancellationToken).ContinueWith(CompleteWriter, pipe.Writer).Unwrap();
 
             try
             {
                 while (true)
                 {
-                    if (!pipe.Reader.TryRead(out ReadResult result))
-                    {
-                        await pipe.Reader.ReadAsync().ConfigureAwait(false);
-                    }
+                    ReadResult result = pipe.Reader.TryRead(out ReadResult readResult)
+                        ? readResult
+                        : await pipe.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
 
                     foreach (ReadOnlyMemory<byte> item in result.Buffer)
                     {
-                        await RandomAccess.WriteAsync(handle, item, offset).ConfigureAwait(false);
+                        await RandomAccess.WriteAsync(handle, item, offset, cancellationToken).ConfigureAwait(false);
                         offset += item.Length;
                     }
 

--- a/src/HaveIBeenPwned.PwnedPasswords.Downloader/Program.cs
+++ b/src/HaveIBeenPwned.PwnedPasswords.Downloader/Program.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Text;
 using System.Threading.Channels;
 
 using HaveIBeenPwned.PwnedPasswords;
@@ -12,9 +13,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Win32.SafeHandles;
-
-using Polly;
-using Polly.Retry;
 
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -82,38 +80,14 @@ internal sealed class Statistics
 
 internal sealed class PwnedPasswordsDownloader : AsyncCommand<PwnedPasswordsDownloader.Settings>
 {
-    private static readonly ResiliencePropertyKey<string> s_resiliencePropertyKey = new("uri");
+    private static readonly TimeSpan s_retryDelay = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan s_maxRetryDelay = TimeSpan.FromSeconds(10);
     private readonly Statistics _statistics = new();
     private readonly HttpClient _httpClient;
-    private readonly ResiliencePipeline<HttpResponseMessage> _pipeline;
 
     public PwnedPasswordsDownloader(IHttpClientFactory httpClientFactory)
     {
         _httpClient = httpClientFactory.CreateClient("PwnedPasswords");
-        _pipeline = new ResiliencePipelineBuilder<HttpResponseMessage>().AddRetry(new RetryStrategyOptions<HttpResponseMessage>
-        {
-            ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
-                .HandleResult(response => !response.IsSuccessStatusCode)
-                .Handle<HttpRequestException>()
-                .Handle<OperationCanceledException>()
-                .Handle<TimeoutException>()
-                .Handle<TaskCanceledException>(),
-            MaxRetryAttempts = 10,
-            BackoffType = DelayBackoffType.Linear,
-            Delay = TimeSpan.FromSeconds(2),
-            MaxDelay = TimeSpan.FromSeconds(10),
-            OnRetry = OnRequestErrorAsync
-        }).Build();
-    }
-
-    static ValueTask OnRequestErrorAsync(OnRetryArguments<HttpResponseMessage> args)
-    {
-        string uri = args.Context.Properties.GetValue(s_resiliencePropertyKey, "");
-        AnsiConsole.MarkupLine(args.Outcome.Exception != null
-            ? $"[yellow]Failed attempt #{args.AttemptNumber} while fetching {uri}. Exception is {args.Outcome.Exception.GetType().Name} and message: {args.Outcome.Exception.Message}.[/]"
-            : $"[yellow]Failed attempt #{args.AttemptNumber} while fetching {uri}. Response contained HTTP Status code {args.Outcome.Result?.StatusCode}.[/]");
-
-        return ValueTask.CompletedTask;
     }
 
     public sealed class Settings : CommandSettings
@@ -141,6 +115,20 @@ internal sealed class PwnedPasswordsDownloader : AsyncCommand<PwnedPasswordsDown
         [CommandOption("-n|--ntlm")]
         [DefaultValue(false)]
         public bool FetchNtlm { get; set; } = false;
+
+        [Description("Maximum number of retries per prefix. Omit for unlimited retries. Use 0 to disable retries.")]
+        [CommandOption("--max-retries")]
+        public int? MaxRetries { get; init; }
+
+        public override ValidationResult Validate()
+        {
+            if (MaxRetries < 0)
+            {
+                return ValidationResult.Error("--max-retries must be 0 or greater.");
+            }
+
+            return ValidationResult.Success();
+        }
     }
 
     public override async Task<int> ExecuteAsync([NotNull] CommandContext context, [NotNull] Settings settings)
@@ -149,6 +137,15 @@ internal sealed class PwnedPasswordsDownloader : AsyncCommand<PwnedPasswordsDown
         {
             settings.Parallelism = Math.Max(Environment.ProcessorCount * 8, 2);
         }
+
+        using CancellationTokenSource cancellationTokenSource = new();
+        ConsoleCancelEventHandler cancelHandler = (_, args) =>
+        {
+            args.Cancel = true;
+            cancellationTokenSource.Cancel();
+        };
+
+        Console.CancelKeyPress += cancelHandler;
 
         try
         {
@@ -189,20 +186,17 @@ internal sealed class PwnedPasswordsDownloader : AsyncCommand<PwnedPasswordsDown
 
                     var timer = Stopwatch.StartNew();
                     ProgressTask progressTask = ctx.AddTask("[green]Hash ranges downloaded[/]", true, 1024 * 1024);
-                    Task processTask = ProcessRanges(settings);
+                    Task processTask = ProcessRanges(settings, cancellationTokenSource.Token);
 
                     do
                     {
                         progressTask.Value = _statistics.HashesDownloaded;
                         ctx.Refresh();
-                        await Task.Delay(100).ConfigureAwait(false);
+                        await Task.Delay(100, cancellationTokenSource.Token).ConfigureAwait(false);
                     }
                     while (!processTask.IsCompleted);
 
-                    if (processTask.Exception is not null)
-                    {
-                        throw processTask.Exception;
-                    }
+                    await processTask.ConfigureAwait(false);
 
                     _statistics.ElapsedMilliseconds = timer.ElapsedMilliseconds;
                     progressTask.Value = _statistics.HashesDownloaded;
@@ -215,6 +209,11 @@ internal sealed class PwnedPasswordsDownloader : AsyncCommand<PwnedPasswordsDown
 
             return 0;
         }
+        catch (OperationCanceledException) when (cancellationTokenSource.IsCancellationRequested)
+        {
+            AnsiConsole.MarkupLine("[yellow]Download canceled.[/]");
+            return -2;
+        }
         catch (Exception e)
         {
             AnsiConsole.MarkupLine($"Failed to download hash ranges: {e.Message}");
@@ -222,27 +221,42 @@ internal sealed class PwnedPasswordsDownloader : AsyncCommand<PwnedPasswordsDown
 
             return -1;
         }
+        finally
+        {
+            Console.CancelKeyPress -= cancelHandler;
+        }
     }
 
-    private async Task<Stream> GetPwnedPasswordsRangeFromWeb(int i, bool fetchNtlm)
+    private async Task<HttpResponseMessage> GetPwnedPasswordsRangeFromWeb(string prefix, bool fetchNtlm, CancellationToken cancellationToken)
     {
-        var cloudflareTimer = Stopwatch.StartNew();
-        string requestUri = GetHashRange(i);
+        Stopwatch cloudflareTimer = Stopwatch.StartNew();
+        string requestUri = prefix;
         if (fetchNtlm)
         {
             requestUri += "?mode=ntlm";
         }
 
-        ResilienceContext context = ResilienceContextPool.Shared.Get();
-        context.Properties.Set(s_resiliencePropertyKey, $"{_httpClient.BaseAddress}{requestUri}");
-        HttpResponseMessage response = await _pipeline.ExecuteAsync(async (ResilienceContext resilienceContext) => await _httpClient.GetAsync(requestUri, resilienceContext.CancellationToken).ConfigureAwait(false), context);
-        ResilienceContextPool.Shared.Return(context);
-        Stream content = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        HttpResponseMessage response = await _httpClient.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         Interlocked.Add(ref _statistics.CloudflareRequestTimeTotal, cloudflareTimer.ElapsedMilliseconds);
         Interlocked.Increment(ref _statistics.CloudflareRequests);
+
+        TrackCloudflareCacheStatus(response);
+
+        if (response.IsSuccessStatusCode)
+        {
+            return response;
+        }
+
+        HttpStatusCode statusCode = response.StatusCode;
+        response.Dispose();
+        throw new HttpRequestException($"Response contained HTTP status code {(int)statusCode} ({statusCode}).", inner: null, statusCode);
+    }
+
+    private void TrackCloudflareCacheStatus(HttpResponseMessage response)
+    {
         if (!response.Headers.TryGetValues("CF-Cache-Status", out IEnumerable<string>? values))
         {
-            return content;
+            return;
         }
 
         switch (values.FirstOrDefault())
@@ -254,8 +268,6 @@ internal sealed class PwnedPasswordsDownloader : AsyncCommand<PwnedPasswordsDown
                 Interlocked.Increment(ref _statistics.CloudflareMisses);
                 break;
         }
-
-        return content;
     }
 
     private static string GetHashRange(int i)
@@ -265,28 +277,18 @@ internal sealed class PwnedPasswordsDownloader : AsyncCommand<PwnedPasswordsDown
         return Convert.ToHexString(bytes)[3..];
     }
 
-    private async Task ProcessRanges(Settings settings)
+    private async Task ProcessRanges(Settings settings, CancellationToken cancellationToken)
     {
         if (settings.SingleFile)
         {
-            Channel<Task<Stream>> downloadTasks = Channel.CreateBounded<Task<Stream>>(new BoundedChannelOptions(settings.Parallelism) { SingleReader = true, SingleWriter = true, AllowSynchronousContinuations = true });
+            Channel<Task<DownloadedRange>> downloadTasks = Channel.CreateBounded<Task<DownloadedRange>>(new BoundedChannelOptions(settings.Parallelism) { SingleReader = true, SingleWriter = true, AllowSynchronousContinuations = true });
             await using FileStream file = File.Open($"{settings.OutputFile}.txt", new FileStreamOptions { Access = FileAccess.Write, BufferSize = 32767, Mode = FileMode.Create, Options = FileOptions.Asynchronous, Share = FileShare.None });
-            await using StreamWriter writer = new(file);
-            Task producerTask = StartDownloads(downloadTasks.Writer, settings.FetchNtlm);
-            await foreach (Task<Stream> item in downloadTasks.Reader.ReadAllAsync().ConfigureAwait(false))
+            Task producerTask = StartDownloads(downloadTasks.Writer, settings, cancellationToken);
+            await foreach (Task<DownloadedRange> item in downloadTasks.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
             {
-                string prefix = GetHashRange(_statistics.HashesDownloaded++);
-                await using Stream inputStream = await item.ConfigureAwait(false);
-                using StreamReader reader = new(inputStream);
-                while (await reader.ReadLineAsync() is { } line)
-                {
-                    if (line.Length > 0)
-                    {
-                        await writer.WriteLineAsync($"{prefix}{line}");
-                    }
-                }
-
-                await writer.FlushAsync();
+                DownloadedRange range = await item.ConfigureAwait(false);
+                await WriteRangeToSingleFile(range, file, settings.MaxRetries, cancellationToken).ConfigureAwait(false);
+                Interlocked.Increment(ref _statistics.HashesDownloaded);
             }
 
             await producerTask.ConfigureAwait(false);
@@ -296,10 +298,11 @@ internal sealed class PwnedPasswordsDownloader : AsyncCommand<PwnedPasswordsDown
             await Parallel.ForEachAsync(EnumerateRanges(), new ParallelOptions
             {
                 MaxDegreeOfParallelism = settings.Parallelism,
-                TaskScheduler = TaskScheduler.Default
+                TaskScheduler = TaskScheduler.Default,
+                CancellationToken = cancellationToken
             }, async (i, _) =>
             {
-                await DownloadRangeToFile(i, settings.OutputFile, settings.FetchNtlm).ConfigureAwait(false);
+                await DownloadRangeToFile(i, settings.OutputFile, settings.FetchNtlm, settings.MaxRetries, cancellationToken).ConfigureAwait(false);
             });
         }
     }
@@ -312,13 +315,13 @@ internal sealed class PwnedPasswordsDownloader : AsyncCommand<PwnedPasswordsDown
         }
     }
 
-    private async Task StartDownloads(ChannelWriter<Task<Stream>> channelWriter, bool fetchNtlm)
+    private async Task StartDownloads(ChannelWriter<Task<DownloadedRange>> channelWriter, Settings settings, CancellationToken cancellationToken)
     {
         try
         {
             foreach (int i in EnumerateRanges())
             {
-                await channelWriter.WriteAsync(GetPwnedPasswordsRangeFromWeb(i, fetchNtlm));
+                await channelWriter.WriteAsync(DownloadRangeToBuffer(i, settings.FetchNtlm, settings.MaxRetries, cancellationToken), cancellationToken).ConfigureAwait(false);
             }
 
             channelWriter.TryComplete();
@@ -329,13 +332,118 @@ internal sealed class PwnedPasswordsDownloader : AsyncCommand<PwnedPasswordsDown
         }
     }
 
-    private async Task DownloadRangeToFile(int currentHash, string outputDirectory, bool fetchNtlm)
+    private async Task<DownloadedRange> DownloadRangeToBuffer(int currentHash, bool fetchNtlm, int? maxRetries, CancellationToken cancellationToken)
     {
-        await using Stream stream = await GetPwnedPasswordsRangeFromWeb(currentHash, fetchNtlm).ConfigureAwait(false);
-        using SafeFileHandle handle = File.OpenHandle(Path.Combine(outputDirectory, $"{GetHashRange(currentHash)}.txt"), FileMode.Create, FileAccess.Write,
-            FileShare.None, FileOptions.Asynchronous);
-        await handle.CopyFrom(stream).ConfigureAwait(false);
+        string prefix = GetHashRange(currentHash);
+
+        return await ExecuteWithRetriesAsync(prefix, "downloading range data", maxRetries, async retryCancellationToken =>
+        {
+            await using MemoryStream output = new();
+            await using StreamWriter writer = new(output, Encoding.UTF8, leaveOpen: true);
+            using HttpResponseMessage response = await GetPwnedPasswordsRangeFromWeb(prefix, fetchNtlm, retryCancellationToken).ConfigureAwait(false);
+            await using Stream stream = await response.Content.ReadAsStreamAsync(retryCancellationToken).ConfigureAwait(false);
+            using StreamReader reader = new(stream);
+
+            while (await reader.ReadLineAsync(retryCancellationToken).ConfigureAwait(false) is { } line)
+            {
+                if (line.Length == 0)
+                {
+                    continue;
+                }
+
+                await writer.WriteAsync(prefix.AsMemory(), retryCancellationToken).ConfigureAwait(false);
+                await writer.WriteLineAsync(line.AsMemory(), retryCancellationToken).ConfigureAwait(false);
+            }
+
+            await writer.FlushAsync(retryCancellationToken).ConfigureAwait(false);
+            return new DownloadedRange(prefix, output.ToArray());
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task WriteRangeToSingleFile(DownloadedRange range, FileStream file, int? maxRetries, CancellationToken cancellationToken)
+    {
+        long startPosition = file.Position;
+
+        await ExecuteWithRetriesAsync(range.Prefix, "writing single-file output", maxRetries, async retryCancellationToken =>
+        {
+            file.Position = startPosition;
+            file.SetLength(startPosition);
+            await file.WriteAsync(range.Content, retryCancellationToken).ConfigureAwait(false);
+            await file.FlushAsync(retryCancellationToken).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task DownloadRangeToFile(int currentHash, string outputDirectory, bool fetchNtlm, int? maxRetries, CancellationToken cancellationToken)
+    {
+        string prefix = GetHashRange(currentHash);
+
+        await ExecuteWithRetriesAsync(prefix, "downloading range file", maxRetries, async retryCancellationToken =>
+        {
+            using HttpResponseMessage response = await GetPwnedPasswordsRangeFromWeb(prefix, fetchNtlm, retryCancellationToken).ConfigureAwait(false);
+            await using Stream stream = await response.Content.ReadAsStreamAsync(retryCancellationToken).ConfigureAwait(false);
+            using SafeFileHandle handle = File.OpenHandle(Path.Combine(outputDirectory, $"{prefix}.txt"), FileMode.Create, FileAccess.Write, FileShare.None, FileOptions.Asynchronous);
+            await handle.CopyFrom(stream, cancellationToken: retryCancellationToken).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
+
         Interlocked.Increment(ref _statistics.HashesDownloaded);
+    }
+
+    private static TimeSpan GetRetryDelay(int retryAttempt) => TimeSpan.FromSeconds(Math.Min(retryAttempt * s_retryDelay.TotalSeconds, s_maxRetryDelay.TotalSeconds));
+
+    private static void WriteRetryMessage(string prefix, string operation, int retryAttempt, int? maxRetries, TimeSpan delay, Exception exception)
+    {
+        string retryLimit = maxRetries is int boundedRetryCount ? $"/{boundedRetryCount}" : string.Empty;
+        string exceptionType = exception.GetType().Name.EscapeMarkup();
+        string exceptionMessage = exception.Message.EscapeMarkup();
+        AnsiConsole.MarkupLine($"[yellow]Retry {retryAttempt}{retryLimit} for prefix {prefix} in {delay.TotalSeconds:N0}s while {operation}. {exceptionType}: {exceptionMessage}[/]");
+    }
+
+    private static bool IsCancellation(Exception exception, CancellationToken cancellationToken) => exception is OperationCanceledException && cancellationToken.IsCancellationRequested;
+
+    private static async Task ExecuteWithRetriesAsync(string prefix, string operation, int? maxRetries, Func<CancellationToken, Task> work, CancellationToken cancellationToken)
+    {
+        await ExecuteWithRetriesAsync<object?>(prefix, operation, maxRetries, async retryCancellationToken =>
+        {
+            await work(retryCancellationToken).ConfigureAwait(false);
+            return null;
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<T> ExecuteWithRetriesAsync<T>(string prefix, string operation, int? maxRetries, Func<CancellationToken, Task<T>> work, CancellationToken cancellationToken)
+    {
+        int retryAttempt = 0;
+
+        while (true)
+        {
+            try
+            {
+                return await work(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception exception) when (!IsCancellation(exception, cancellationToken))
+            {
+                if (maxRetries is int boundedRetryCount && retryAttempt >= boundedRetryCount)
+                {
+                    throw;
+                }
+
+                retryAttempt++;
+                TimeSpan delay = GetRetryDelay(retryAttempt);
+                WriteRetryMessage(prefix, operation, retryAttempt, maxRetries, delay, exception);
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private sealed class DownloadedRange
+    {
+        public DownloadedRange(string prefix, byte[] content)
+        {
+            Prefix = prefix;
+            Content = content;
+        }
+
+        public string Prefix { get; }
+        public byte[] Content { get; }
     }
 }
 


### PR DESCRIPTION
Added --max-retries CLI option for configurable retry limits per prefix. Replaced Polly with custom retry logic supporting exponential backoff, user feedback, and cancellation. All download and file write operations now support retries and cancellation tokens. Improved Ctrl+C handling for graceful cancellation. Updated documentation and code comments accordingly.