### PR TITLE
AOT and downloads verification

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -42,7 +42,7 @@ jobs:
           rid: win-arm64
         - os: ubuntu-latest
           rid: linux-x64
-        - os: ubuntu-latest
+        - os: ubuntu-24.04-arm
           rid: linux-arm64
         - os: macos-13
           rid: osx-x64

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -48,10 +48,10 @@ jobs:
           rid: osx-arm64
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Setup .NET 10.0 SDK
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0.x
 
@@ -83,7 +83,7 @@ jobs:
         }
 
     - name: Upload RID-specific package
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nupkg-${{ matrix.rid }}
         path: ${{ github.workspace }}/packages/*.${{ matrix.rid }}.*.nupkg
@@ -98,10 +98,10 @@ jobs:
       VersionPrefix: ${{ needs.version.outputs.version-prefix }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Setup .NET 10.0 SDK
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0.x
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -44,8 +44,6 @@ jobs:
           rid: linux-x64
         - os: ubuntu-24.04-arm
           rid: linux-arm64
-        - os: macos-13
-          rid: osx-x64
         - os: macos-14
           rid: osx-arm64
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -90,7 +90,7 @@ jobs:
         if-no-files-found: error
 
   package-pointer:
-    name: "Package tool pointer"
+    name: "Package fallback and tool pointer"
     needs: version
     runs-on: ubuntu-latest
 
@@ -105,6 +105,21 @@ jobs:
       with:
         dotnet-version: 10.0.x
 
+    - name: Package framework-dependent fallback
+      run: >
+        dotnet pack ./src/HaveIBeenPwned.PwnedPasswords.Downloader/HaveIBeenPwned.PwnedPasswords.Downloader.csproj
+        --configuration Release
+        --runtime any
+        -p:PublishAot=false
+        -p:VersionPrefix="${VersionPrefix}"
+        -p:PackageOutputPath="${GITHUB_WORKSPACE}/fallback-package"
+
+    - name: Validate framework-dependent fallback
+      run: |
+        package="${GITHUB_WORKSPACE}/fallback-package/haveibeenpwned-downloader.any.${VersionPrefix}.nupkg"
+        test -f "${package}"
+        unzip -Z1 "${package}" | grep -Fx 'tools/net10.0/any/haveibeenpwned-downloader.dll'
+
     - name: Package tool pointer
       run: >
         dotnet pack ./src/HaveIBeenPwned.PwnedPasswords.Downloader/HaveIBeenPwned.PwnedPasswords.Downloader.csproj
@@ -113,4 +128,8 @@ jobs:
         -p:PackageOutputPath="${GITHUB_WORKSPACE}/pointer-package"
 
     - name: Validate pointer package
-      run: test -f "${GITHUB_WORKSPACE}/pointer-package/haveibeenpwned-downloader.${VersionPrefix}.nupkg"
+      run: |
+        package="${GITHUB_WORKSPACE}/pointer-package/haveibeenpwned-downloader.${VersionPrefix}.nupkg"
+        test -f "${package}"
+        unzip -p "${package}" 'tools/any/any/DotnetToolSettings.xml' |
+          grep -F 'RuntimeIdentifier="any" Id="haveibeenpwned-downloader.any"'

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -7,37 +7,112 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-    name: "Build Project"
+  version:
+    name: "Set package version"
     runs-on: ubuntu-latest
 
     env:
       MajorVersion: 0
       MinorVersion: 5
+
+    outputs:
+      version-prefix: ${{ steps.version.outputs.version-prefix }}
+
     steps:
-    - uses: actions/checkout@v2
-
-    - name: Get current date
-      id: version
-      run: echo "::set-output name=date::$(date +'%Y%m.%d')"
-
-    - name: Get branch name (merge)
-      if: github.event_name != 'pull_request'
-      run: echo "Branch=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
-
-    - name: Get branch name (pull request)
-      if: github.event_name == 'pull_request'
-      run: echo "Branch=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
-
     - name: Set Version Prefix
-      env:
-        VERPREF: ${{ format('{0}.{1}.{2}{3}', env.MajorVersion, env.MinorVersion, steps.date.outputs.date, github.run_number) }}
-      run: echo "VersionPrefix=$(echo ${VERPREF})" >> $GITHUB_ENV
-    
-    - name: Setup .NET 9.0 SDK
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 9.x
+      id: version
+      run: echo "version-prefix=${MajorVersion}.${MinorVersion}.$(date +'%y%m').$(date +'%d')${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
 
-    - name: Build Project
-      run: dotnet pack ./src/HaveIBeenPwned.PwnedPasswords.Downloader/HaveIBeenPwned.PwnedPasswords.Downloader.csproj --configuration Release
+  package-rid:
+    name: "Package Native AOT (${{ matrix.rid }})"
+    needs: version
+    runs-on: ${{ matrix.os }}
+
+    env:
+      RID: ${{ matrix.rid }}
+      VersionPrefix: ${{ needs.version.outputs.version-prefix }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - os: windows-latest
+          rid: win-x64
+        - os: windows-latest
+          rid: win-arm64
+        - os: ubuntu-latest
+          rid: linux-x64
+        - os: ubuntu-latest
+          rid: linux-arm64
+        - os: macos-13
+          rid: osx-x64
+        - os: macos-14
+          rid: osx-arm64
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET 10.0 SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Package Native AOT tool
+      shell: pwsh
+      run: >
+        dotnet pack ./src/HaveIBeenPwned.PwnedPasswords.Downloader/HaveIBeenPwned.PwnedPasswords.Downloader.csproj
+        --configuration Release
+        --runtime $env:RID
+        -p:VersionPrefix="$env:VersionPrefix"
+        -p:PackageOutputPath="$env:GITHUB_WORKSPACE/packages"
+
+    - name: Validate RID-specific package
+      shell: pwsh
+      run: |
+        $packages = @(Get-ChildItem "$env:GITHUB_WORKSPACE/packages" -File -Filter "*.$env:RID.*.nupkg")
+        if ($packages.Count -ne 1) {
+          throw "Expected exactly one $env:RID Native AOT package, found $($packages.Count)."
+        }
+
+        $archive = [System.IO.Compression.ZipFile]::OpenRead($packages[0].FullName)
+        try {
+          if (-not ($archive.Entries | Where-Object FullName -like 'tools/*')) {
+            throw "The $env:RID package does not contain tool payload files."
+          }
+        }
+        finally {
+          $archive.Dispose()
+        }
+
+    - name: Upload RID-specific package
+      uses: actions/upload-artifact@v4
+      with:
+        name: nupkg-${{ matrix.rid }}
+        path: ${{ github.workspace }}/packages/*.${{ matrix.rid }}.*.nupkg
+        if-no-files-found: error
+
+  package-pointer:
+    name: "Package tool pointer"
+    needs: version
+    runs-on: ubuntu-latest
+
+    env:
+      VersionPrefix: ${{ needs.version.outputs.version-prefix }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET 10.0 SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Package tool pointer
+      run: >
+        dotnet pack ./src/HaveIBeenPwned.PwnedPasswords.Downloader/HaveIBeenPwned.PwnedPasswords.Downloader.csproj
+        --configuration Release
+        -p:VersionPrefix="${VersionPrefix}"
+        -p:PackageOutputPath="${GITHUB_WORKSPACE}/pointer-package"
+
+    - name: Validate pointer package
+      run: test -f "${GITHUB_WORKSPACE}/pointer-package/haveibeenpwned-downloader.${VersionPrefix}.nupkg"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Setup .NET 10.0 SDK
       uses: actions/setup-dotnet@v6
       with:
-        dotnet-version: 10.0.x
+        dotnet-version: 10.x
 
     - name: Package Native AOT tool
       shell: pwsh
@@ -103,7 +103,7 @@ jobs:
     - name: Setup .NET 10.0 SDK
       uses: actions/setup-dotnet@v6
       with:
-        dotnet-version: 10.0.x
+        dotnet-version: 10.x
 
     - name: Package framework-dependent fallback
       run: >

--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -118,7 +118,16 @@ jobs:
         path: ${{ github.workspace }}/packages
         merge-multiple: true
 
-    - name: Publish RID-specific packages
+    - name: Package framework-dependent fallback
+      run: >
+        dotnet pack ./src/HaveIBeenPwned.PwnedPasswords.Downloader/HaveIBeenPwned.PwnedPasswords.Downloader.csproj
+        --configuration Release
+        --runtime any
+        -p:PublishAot=false
+        -p:VersionPrefix="${VersionPrefix}"
+        -p:PackageOutputPath="${GITHUB_WORKSPACE}/packages"
+
+    - name: Publish runtime packages
       shell: bash
       run: |
         find "${GITHUB_WORKSPACE}/packages" -type f -name '*.nupkg' -print0 |

--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -42,8 +42,6 @@ jobs:
           rid: linux-x64
         - os: ubuntu-24.04-arm
           rid: linux-arm64
-        - os: macos-13
-          rid: osx-x64
         - os: macos-14
           rid: osx-arm64
 

--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -5,50 +5,138 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-    name: "Build Project"
+  version:
+    name: "Set package version"
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write  # enable GitHub OIDC token issuance for this job
 
     env:
       MajorVersion: 0
       MinorVersion: 5
-    steps:
-    - uses: actions/checkout@v2
 
-    # Get a short-lived NuGet API key
+    outputs:
+      version-prefix: ${{ steps.version.outputs.version-prefix }}
+
+    steps:
+    - name: Set Version Prefix
+      id: version
+      run: echo "version-prefix=${MajorVersion}.${MinorVersion}.$(date +'%y%m').$(date +'%d')${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+
+  package-rid:
+    name: "Package Native AOT (${{ matrix.rid }})"
+    needs: version
+    runs-on: ${{ matrix.os }}
+
+    env:
+      RID: ${{ matrix.rid }}
+      VersionPrefix: ${{ needs.version.outputs.version-prefix }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - os: windows-latest
+          rid: win-x64
+        - os: windows-latest
+          rid: win-arm64
+        - os: ubuntu-latest
+          rid: linux-x64
+        - os: ubuntu-latest
+          rid: linux-arm64
+        - os: macos-13
+          rid: osx-x64
+        - os: macos-14
+          rid: osx-arm64
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET 10.0 SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Package Native AOT tool
+      shell: pwsh
+      run: >
+        dotnet pack ./src/HaveIBeenPwned.PwnedPasswords.Downloader/HaveIBeenPwned.PwnedPasswords.Downloader.csproj
+        --configuration Release
+        --runtime $env:RID
+        -p:VersionPrefix="$env:VersionPrefix"
+        -p:PackageOutputPath="$env:GITHUB_WORKSPACE/packages"
+
+    - name: Validate RID-specific package
+      shell: pwsh
+      run: |
+        $packages = @(Get-ChildItem "$env:GITHUB_WORKSPACE/packages" -File -Filter "*.$env:RID.*.nupkg")
+        if ($packages.Count -ne 1) {
+          throw "Expected exactly one $env:RID Native AOT package, found $($packages.Count)."
+        }
+
+        $archive = [System.IO.Compression.ZipFile]::OpenRead($packages[0].FullName)
+        try {
+          if (-not ($archive.Entries | Where-Object FullName -like 'tools/*')) {
+            throw "The $env:RID package does not contain tool payload files."
+          }
+        }
+        finally {
+          $archive.Dispose()
+        }
+
+    - name: Upload RID-specific package
+      uses: actions/upload-artifact@v4
+      with:
+        name: nupkg-${{ matrix.rid }}
+        path: ${{ github.workspace }}/packages/*.${{ matrix.rid }}.*.nupkg
+        if-no-files-found: error
+
+  publish:
+    name: "Publish packages"
+    needs: [version, package-rid]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    env:
+      VersionPrefix: ${{ needs.version.outputs.version-prefix }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET 10.0 SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+
     - name: NuGet login (OIDC → temp API key)
       uses: NuGet/login@v1
       id: login
       with:
         user: ${{ secrets.NUGET_USER }}
-        
-    - name: Get current date
-      id: version
-      run: echo "::set-output name=date::$(date +'%Y%m.%d')"
 
-    - name: Get branch name (merge)
-      if: github.event_name != 'pull_request'
-      run: echo "Branch=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
-
-    - name: Get branch name (pull request)
-      if: github.event_name == 'pull_request'
-      run: echo "Branch=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
-
-    - name: Set Version Prefix
-      env:
-        VERPREF: ${{ format('{0}.{1}.{2}{3}', env.MajorVersion, env.MinorVersion, steps.date.outputs.date, github.run_number) }}
-      run: echo "VersionPrefix=$(echo ${VERPREF})" >> $GITHUB_ENV
-    
-    - name: Setup .NET 9.0 SDK
-      uses: actions/setup-dotnet@v1
+    - name: Download RID-specific packages
+      uses: actions/download-artifact@v4
       with:
-        dotnet-version: 9.x
+        pattern: nupkg-*
+        path: ${{ github.workspace }}/packages
+        merge-multiple: true
 
-    - name: Build Project
-      run: dotnet pack ./src/HaveIBeenPwned.PwnedPasswords.Downloader/HaveIBeenPwned.PwnedPasswords.Downloader.csproj --configuration Release
-    
-    # Push the package
-    - name: NuGet push
-      run: dotnet nuget push  ./src/HaveIBeenPwned.PwnedPasswords.Downloader/nupkg/*.nupkg --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols 
+    - name: Publish RID-specific packages
+      shell: bash
+      run: |
+        find "${GITHUB_WORKSPACE}/packages" -type f -name '*.nupkg' -print0 |
+          xargs -0 -r -n 1 dotnet nuget push --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols
+
+    - name: Package tool pointer
+      run: >
+        dotnet pack ./src/HaveIBeenPwned.PwnedPasswords.Downloader/HaveIBeenPwned.PwnedPasswords.Downloader.csproj
+        --configuration Release
+        -p:VersionPrefix="${VersionPrefix}"
+        -p:PackageOutputPath="${GITHUB_WORKSPACE}/pointer-package"
+
+    - name: Publish tool pointer
+      run: >
+        dotnet nuget push "${GITHUB_WORKSPACE}/pointer-package/haveibeenpwned-downloader.${VersionPrefix}.nupkg"
+        --api-key "${{ steps.login.outputs.NUGET_API_KEY }}"
+        --source https://api.nuget.org/v3/index.json
+        --skip-duplicate
+        --no-symbols

--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -46,10 +46,10 @@ jobs:
           rid: osx-arm64
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Setup .NET 10.0 SDK
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0.x
 
@@ -81,7 +81,7 @@ jobs:
         }
 
     - name: Upload RID-specific package
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nupkg-${{ matrix.rid }}
         path: ${{ github.workspace }}/packages/*.${{ matrix.rid }}.*.nupkg
@@ -98,7 +98,7 @@ jobs:
       VersionPrefix: ${{ needs.version.outputs.version-prefix }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Setup .NET 10.0 SDK
       uses: actions/setup-dotnet@v4
@@ -112,7 +112,7 @@ jobs:
         user: ${{ secrets.NUGET_USER }}
 
     - name: Download RID-specific packages
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         pattern: nupkg-*
         path: ${{ github.workspace }}/packages

--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -40,7 +40,7 @@ jobs:
           rid: win-arm64
         - os: ubuntu-latest
           rid: linux-x64
-        - os: ubuntu-latest
+        - os: ubuntu-24.04-arm
           rid: linux-arm64
         - os: macos-13
           rid: osx-x64

--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Setup .NET 10.0 SDK
       uses: actions/setup-dotnet@v6
       with:
-        dotnet-version: 10.0.x
+        dotnet-version: 10.x
 
     - name: Package Native AOT tool
       shell: pwsh
@@ -101,9 +101,9 @@ jobs:
     - uses: actions/checkout@v7
 
     - name: Setup .NET 10.0 SDK
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v6
       with:
-        dotnet-version: 10.0.x
+        dotnet-version: 10.x
 
     - name: NuGet login (OIDC → temp API key)
       uses: NuGet/login@v1

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An alternative to running this tool is to use Zsolt Müller's cURL approach in h
 # Installation
 
 ## Prerequisites
-You'll need to install the latest [LTS (Long Term Support)](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) or [STS (Short Term Support)](https://dotnet.microsoft.com/en-us/download/dotnet/9.0) version of the .NET SDK to be able to install and run the tool.
+Install the [.NET 10 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) or later to install the tool. Native AOT, self-contained packages are available for Windows x64, Linux x64, macOS x64, and macOS Apple silicon; the installed tool does not require a separate .NET runtime.
 
 ## How to install
 1. Open a command line window
@@ -28,13 +28,13 @@ dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org
 
 
 ### Download all SHA1 hashes to a single txt file called `pwnedpasswords.txt`
-`haveibeenpwned-downloader.exe pwnedpasswords`
+`haveibeenpwned-downloader.exe pwnedpasswords --single`
 
 ### Download all SHA1 hashes to individual txt files into a custom directory called `hashes`
-`haveibeenpwned-downloader.exe pwnedpasswords -s false`
+`haveibeenpwned-downloader.exe hashes`
 
 ### Download all NTLM hashes to a single txt file called `pwnedpasswords_ntlm.txt`
-`haveibeenpwned-downloader.exe -n pwnedpasswords_ntlm`
+`haveibeenpwned-downloader.exe -n pwnedpasswords_ntlm --single`
 
 
 
@@ -42,13 +42,13 @@ dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org
 
 
 ### Download all SHA1 hashes to a single txt file called `pwnedpasswords.txt` :
-`haveibeenpwned-downloader pwnedpasswords`
+`haveibeenpwned-downloader pwnedpasswords --single`
 
 ### Download all SHA1 hashes to individual txt files into a custom directory called `hashes`:
-`haveibeenpwned-downloader pwnedpasswords -s false`
+`haveibeenpwned-downloader hashes`
 
 ### Download all NTLM hashes to a single txt file called `pwnedpasswords_ntlm.txt` : 
-`haveibeenpwned-downloader -n pwnedpasswords_ntlm`
+`haveibeenpwned-downloader -n pwnedpasswords_ntlm --single`
 
 
 
@@ -56,7 +56,7 @@ dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org
 
 | Parameter   | Default value | Description |
 |-------------|---------------|-------------|
-| -s/--single | true | Determines whether to download hashes to a single file or as individual .txt files into another directory |
+| -s/--single | false | When set, downloads hashes to a single file instead of individual .txt files in a directory |
 | -p/--parallelism | Same as `Environment.ProcessorCount` | Determines how many hashes to download at a time |
 | --max-retries | Unlimited | Determines how many times each prefix is retried after a failure. Omit for unlimited retries, or pass `0` to disable retries. Retry delays increase per prefix up to 10 seconds. |
 | -o/--overwrite | false | Determines if output files should be overwritten or not |
@@ -64,8 +64,8 @@ dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org
 
 # Additional usage examples
 ## Download all hashes to individual txt files into a custom directory called `hashes` using 64 threads to download the hashes
-`haveibeenpwned-downloader.exe hashes -s false -p 64`
+`haveibeenpwned-downloader.exe hashes -p 64`
 ## Download all hashes to a single txt file called `pwnedpasswords.txt` using 64 threads, overwriting the file if it already exists
-`haveibeenpwned-downloader.exe pwnedpasswords -o -p 64`
+`haveibeenpwned-downloader.exe pwnedpasswords --single -o -p 64`
 ## Download all hashes with at most 5 retries per prefix
 `haveibeenpwned-downloader.exe pwnedpasswords --max-retries 5`

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An alternative to running this tool is to use Zsolt Müller's cURL approach in h
 # Installation
 
 ## Prerequisites
-Install the [.NET 10 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) or later to install the tool. Native AOT, self-contained packages are available for Windows x64, Linux x64, macOS x64, and macOS Apple silicon; the installed tool does not require a separate .NET runtime.
+Install the [.NET 10 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) or later to install the tool. Native AOT, self-contained packages are available for Windows x64, Linux x64, and macOS Apple silicon; the installed tool does not require a separate .NET runtime.
 
 ## How to install
 1. Open a command line window

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An alternative to running this tool is to use Zsolt Müller's cURL approach in h
 # Installation
 
 ## Prerequisites
-Install the [.NET 10 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) or later to install the tool. Native AOT, self-contained packages are available for Windows x64, Linux x64, and macOS Apple silicon; the installed tool does not require a separate .NET runtime.
+Install the [.NET 10 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) or later to install the tool. Native AOT, self-contained packages are available for Windows x64, Linux x64, and macOS Apple silicon; the installed tool does not require a separate .NET runtime. Other runtime combinations use a framework-dependent fallback package and require the .NET 10 runtime.
 
 ## How to install
 1. Open a command line window

--- a/src/HaveIBeenPwned.PwnedPasswords.Downloader/HaveIBeenPwned.PwnedPasswords.Downloader.csproj
+++ b/src/HaveIBeenPwned.PwnedPasswords.Downloader/HaveIBeenPwned.PwnedPasswords.Downloader.csproj
@@ -18,8 +18,8 @@
     <PublishTrimmed>true</PublishTrimmed>
     <PublishAot>true</PublishAot>
     <StripSymbols>true</StripSymbols>
-    <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
-    <ToolPackageRuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</ToolPackageRuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-arm64</RuntimeIdentifiers>
+    <ToolPackageRuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-arm64</ToolPackageRuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HaveIBeenPwned.PwnedPasswords.Downloader/HaveIBeenPwned.PwnedPasswords.Downloader.csproj
+++ b/src/HaveIBeenPwned.PwnedPasswords.Downloader/HaveIBeenPwned.PwnedPasswords.Downloader.csproj
@@ -19,7 +19,7 @@
     <PublishAot>true</PublishAot>
     <StripSymbols>true</StripSymbols>
     <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-arm64</RuntimeIdentifiers>
-    <ToolPackageRuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-arm64</ToolPackageRuntimeIdentifiers>
+    <ToolPackageRuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-arm64;any</ToolPackageRuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HaveIBeenPwned.PwnedPasswords.Downloader/HaveIBeenPwned.PwnedPasswords.Downloader.csproj
+++ b/src/HaveIBeenPwned.PwnedPasswords.Downloader/HaveIBeenPwned.PwnedPasswords.Downloader.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
@@ -16,21 +16,25 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <IsAotCompatible>true</IsAotCompatible>
     <PublishTrimmed>true</PublishTrimmed>
-    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <PublishAot>true</PublishAot>
+    <StripSymbols>true</StripSymbols>
     <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <ToolPackageRuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</ToolPackageRuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.4.0" />
-    <PackageReference Include="Spectre.Console" Version="0.50.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.11" />
+    <PackageReference Include="Spectre.Console" Version="0.57.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.11" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     <None Include="..\..\.github\images\hibp.png" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="DotNet.ReproducibleBuilds" Version="2.0.5" />
   </ItemGroup>
 </Project>

--- a/src/HaveIBeenPwned.PwnedPasswords.Downloader/HaveIBeenPwned.PwnedPasswords.Downloader.csproj
+++ b/src/HaveIBeenPwned.PwnedPasswords.Downloader/HaveIBeenPwned.PwnedPasswords.Downloader.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackAsTool>true</PackAsTool>
@@ -14,16 +14,19 @@
     <PackageIcon>hibp.png</PackageIcon>
     <PackageTags>haveibeenpwned hibp pwnedpasswords security password</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <ServerGarbageCollection>true</ServerGarbageCollection>
-    <DebugType>embedded</DebugType>
-    <DebugSymbols>true</DebugSymbols>
+    <IsAotCompatible>true</IsAotCompatible>
+    <PublishTrimmed>true</PublishTrimmed>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <PublishAot>true</PublishAot>
+    <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
+    <ToolPackageRuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</ToolPackageRuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.4.0" />
-    <PackageReference Include="Spectre.Console.Cli" Version="0.50.0" />
-    <PackageReference Include="System.IO.Pipelines" Version="9.0.4" />
+    <PackageReference Include="Spectre.Console" Version="0.50.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HaveIBeenPwned.PwnedPasswords.Downloader/Helpers.cs
+++ b/src/HaveIBeenPwned.PwnedPasswords.Downloader/Helpers.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.IO.Pipelines;
+using System.Security.Cryptography;
 using Microsoft.Win32.SafeHandles;
 
 namespace HaveIBeenPwned.PwnedPasswords
@@ -31,7 +32,7 @@ namespace HaveIBeenPwned.PwnedPasswords
             }
         }
 
-        internal static async Task CopyFrom<T>(this SafeFileHandle handle, T stream, int offset = 0, CancellationToken cancellationToken = default) where T : Stream
+        internal static async Task CopyFrom<T>(this SafeFileHandle handle, T stream, IncrementalHash? hash = null, int offset = 0, CancellationToken cancellationToken = default) where T : Stream
         {
             Pipe pipe = GetPipe();
             Task copyTask = stream.CopyToAsync(pipe.Writer, cancellationToken).ContinueWith(CompleteWriter, pipe.Writer).Unwrap();
@@ -46,6 +47,7 @@ namespace HaveIBeenPwned.PwnedPasswords
 
                     foreach (ReadOnlyMemory<byte> item in result.Buffer)
                     {
+                        hash?.AppendData(item.Span);
                         await RandomAccess.WriteAsync(handle, item, offset, cancellationToken).ConfigureAwait(false);
                         offset += item.Length;
                     }

--- a/src/HaveIBeenPwned.PwnedPasswords.Downloader/Program.cs
+++ b/src/HaveIBeenPwned.PwnedPasswords.Downloader/Program.cs
@@ -1,9 +1,9 @@
 ﻿using System.Buffers.Binary;
-using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
+using System.CommandLine;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Channels;
 
@@ -15,33 +15,24 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Win32.SafeHandles;
 
 using Spectre.Console;
-using Spectre.Console.Cli;
-
-IHostBuilder host = CreateHostBuilder(args);
-host.ConfigureLogging(builder =>
-{
-    builder.ClearProviders();
-});
-
-var registrar = new TypeRegistrar(host);
-
-var app = new CommandApp<PwnedPasswordsDownloader>(registrar);
-
-app.Configure(config => config.PropagateExceptions());
 
 try
 {
-    return await app.RunAsync(args);
+    using IHost host = CreateHostBuilder(args).Build();
+    PwnedPasswordsDownloader downloader = host.Services.GetRequiredService<PwnedPasswordsDownloader>();
+    RootCommand command = CreateRootCommand(downloader);
+    return await command.Parse(args).InvokeAsync();
 }
 catch (Exception ex)
 {
-    AnsiConsole.WriteException(ex, ExceptionFormats.ShortenEverything);
+    ConsoleExceptionWriter.Write(ex);
     return -99;
 }
 
 static IHostBuilder CreateHostBuilder(string[] args) =>
     Host
     .CreateDefaultBuilder(args)
+    .ConfigureLogging(builder => builder.ClearProviders())
     .ConfigureServices((hostContext, services) =>
     {
         services
@@ -51,6 +42,7 @@ static IHostBuilder CreateHostBuilder(string[] args) =>
             handler.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
             handler.SslOptions.EnabledSslProtocols = System.Security.Authentication.SslProtocols.Tls13 | System.Security.Authentication.SslProtocols.Tls12;
             handler.EnableMultipleHttp2Connections = true;
+            handler.EnableMultipleHttp3Connections = true;
         })
         .ConfigureHttpClient(client =>
         {
@@ -61,11 +53,73 @@ static IHostBuilder CreateHostBuilder(string[] args) =>
                 client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("hibp-downloader", FileVersionInfo.GetVersionInfo(process).ProductVersion));
             }
 
-            client.DefaultRequestVersion = HttpVersion.Version20;
+            client.DefaultRequestVersion = HttpVersion.Version30;
             client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
             client.Timeout = TimeSpan.FromSeconds(5);
         });
+
+        services.AddSingleton<PwnedPasswordsDownloader>();
     });
+
+static RootCommand CreateRootCommand(PwnedPasswordsDownloader downloader)
+{
+    Argument<string> outputFileArgument = new("outputFile")
+    {
+        Description = "Name of the output. Defaults to pwnedpasswords, which writes hash ranges to a directory called pwnedpasswords. Use --single to write pwnedpasswords.txt instead.",
+        DefaultValueFactory = _ => "pwnedpasswords"
+    };
+    Option<int> parallelismOption = new("--parallelism", "-p")
+    {
+        Description = "The number of parallel requests to make to Have I Been Pwned to download the hash ranges. If omitted or less than 2, defaults to eight times the number of processors on the machine.",
+        DefaultValueFactory = _ => 0
+    };
+    Option<bool> overwriteOption = new("--overwrite", "-o")
+    {
+        Description = "Overwrite existing files while writing the results."
+    };
+    Option<bool> singleFileOption = new("--single", "-s")
+    {
+        Description = "Write the hash ranges into a single .txt file instead of individual files in a directory."
+    };
+    Option<bool> fetchNtlmOption = new("--ntlm", "-n")
+    {
+        Description = "Fetch NTLM hashes instead of SHA1."
+    };
+    Option<int?> maxRetriesOption = new("--max-retries")
+    {
+        Description = "Maximum number of retries per prefix. Omit for unlimited retries. Use 0 to disable retries."
+    };
+
+    RootCommand command = new("Download Pwned Passwords hash ranges for offline use.");
+    command.Arguments.Add(outputFileArgument);
+    command.Options.Add(parallelismOption);
+    command.Options.Add(overwriteOption);
+    command.Options.Add(singleFileOption);
+    command.Options.Add(fetchNtlmOption);
+    command.Options.Add(maxRetriesOption);
+    command.SetAction(async (parseResult, cancellationToken) =>
+    {
+        PwnedPasswordsDownloader.Settings settings = new()
+        {
+            OutputFile = parseResult.GetValue(outputFileArgument) ?? "pwnedpasswords",
+            Parallelism = parseResult.GetValue(parallelismOption),
+            Overwrite = parseResult.GetValue(overwriteOption),
+            SingleFile = parseResult.GetValue(singleFileOption),
+            FetchNtlm = parseResult.GetValue(fetchNtlmOption),
+            MaxRetries = parseResult.GetValue(maxRetriesOption)
+        };
+
+        if (settings.MaxRetries < 0)
+        {
+            AnsiConsole.MarkupLine("[red]--max-retries must be 0 or greater.[/]");
+            return 1;
+        }
+
+        return await downloader.ExecuteAsync(settings, cancellationToken).ConfigureAwait(false);
+    });
+
+    return command;
+}
 
 internal sealed class Statistics
 {
@@ -78,7 +132,13 @@ internal sealed class Statistics
     public double HashesPerSecond => HashesDownloaded / (ElapsedMilliseconds / 1000.0);
 }
 
-internal sealed class PwnedPasswordsDownloader : AsyncCommand<PwnedPasswordsDownloader.Settings>
+internal static class ConsoleExceptionWriter
+{
+    internal static void Write(Exception exception) =>
+        AnsiConsole.MarkupLine($"[red]{exception.GetType().Name.EscapeMarkup()}: {exception.Message.EscapeMarkup()}[/]");
+}
+
+internal sealed class PwnedPasswordsDownloader
 {
     private static readonly TimeSpan s_retryDelay = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan s_maxRetryDelay = TimeSpan.FromSeconds(10);
@@ -90,55 +150,32 @@ internal sealed class PwnedPasswordsDownloader : AsyncCommand<PwnedPasswordsDown
         _httpClient = httpClientFactory.CreateClient("PwnedPasswords");
     }
 
-    public sealed class Settings : CommandSettings
+    public sealed class Settings
     {
-        [Description("Name of the output. Defaults to pwnedpasswords, which writes the output to pwnedpasswords.txt for single file output, or a directory called pwnedpasswords.")]
-        [CommandArgument(0, "[outputFile]")]
         public string OutputFile { get; init; } = "pwnedpasswords";
-
-        [Description("The number of parallel requests to make to Have I Been Pwned to download the hash ranges. If omitted or less than 2, defaults to eight times the number of processors on the machine.")]
-        [CommandOption("-p||--parallelism")]
-        [DefaultValue(0)]
-        public int Parallelism { get; set; }
-
-        [Description("When set, overwrite any existing files while writing the results. Defaults to false.")]
-        [CommandOption("-o|--overwrite")]
-        [DefaultValue(false)]
-        public bool Overwrite { get; set; } = false;
-
-        [Description("When set, writes the hash ranges into a single .txt file. Otherwise downloads ranges to individual files into a subfolder. If ommited defaults to single file.")]
-        [CommandOption("-s|--single")]
-        [DefaultValue(true)]
-        public bool SingleFile { get; set; } = true;
-
-        [Description("When set, fetches NTLM hashes instead of SHA1.")]
-        [CommandOption("-n|--ntlm")]
-        [DefaultValue(false)]
-        public bool FetchNtlm { get; set; } = false;
-
-        [Description("Maximum number of retries per prefix. Omit for unlimited retries. Use 0 to disable retries.")]
-        [CommandOption("--max-retries")]
+        public int Parallelism { get; init; }
+        public bool Overwrite { get; init; }
+        public bool SingleFile { get; init; }
+        public bool FetchNtlm { get; init; }
         public int? MaxRetries { get; init; }
-
-        public override ValidationResult Validate()
-        {
-            if (MaxRetries < 0)
-            {
-                return ValidationResult.Error("--max-retries must be 0 or greater.");
-            }
-
-            return ValidationResult.Success();
-        }
     }
 
-    public override async Task<int> ExecuteAsync([NotNull] CommandContext context, [NotNull] Settings settings)
+    public async Task<int> ExecuteAsync(Settings settings, CancellationToken commandCancellationToken)
     {
         if (settings.Parallelism < 2)
         {
-            settings.Parallelism = Math.Max(Environment.ProcessorCount * 8, 2);
+            settings = new Settings
+            {
+                OutputFile = settings.OutputFile,
+                Parallelism = Math.Max(Environment.ProcessorCount * 8, 2),
+                Overwrite = settings.Overwrite,
+                SingleFile = settings.SingleFile,
+                FetchNtlm = settings.FetchNtlm,
+                MaxRetries = settings.MaxRetries
+            };
         }
 
-        using CancellationTokenSource cancellationTokenSource = new();
+        using CancellationTokenSource cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(commandCancellationToken);
         ConsoleCancelEventHandler cancelHandler = (_, args) =>
         {
             args.Cancel = true;
@@ -217,7 +254,7 @@ internal sealed class PwnedPasswordsDownloader : AsyncCommand<PwnedPasswordsDown
         catch (Exception e)
         {
             AnsiConsole.MarkupLine($"Failed to download hash ranges: {e.Message}");
-            AnsiConsole.WriteException(e);
+            ConsoleExceptionWriter.Write(e);
 
             return -1;
         }
@@ -338,11 +375,17 @@ internal sealed class PwnedPasswordsDownloader : AsyncCommand<PwnedPasswordsDown
 
         return await ExecuteWithRetriesAsync(prefix, "downloading range data", maxRetries, async retryCancellationToken =>
         {
+            using HttpResponseMessage response = await GetPwnedPasswordsRangeFromWeb(prefix, fetchNtlm, retryCancellationToken).ConfigureAwait(false);
+            byte[] expectedContentMd5 = GetContentMd5(response);
+            await using Stream stream = await response.Content.ReadAsStreamAsync(retryCancellationToken).ConfigureAwait(false);
+            await using MemoryStream responseContent = new();
+            await stream.CopyToAsync(responseContent, retryCancellationToken).ConfigureAwait(false);
+            ValidateContentMd5(expectedContentMd5, responseContent.GetBuffer().AsSpan(0, checked((int)responseContent.Length)));
+
+            responseContent.Position = 0;
             await using MemoryStream output = new();
             await using StreamWriter writer = new(output, Encoding.UTF8, leaveOpen: true);
-            using HttpResponseMessage response = await GetPwnedPasswordsRangeFromWeb(prefix, fetchNtlm, retryCancellationToken).ConfigureAwait(false);
-            await using Stream stream = await response.Content.ReadAsStreamAsync(retryCancellationToken).ConfigureAwait(false);
-            using StreamReader reader = new(stream);
+            using StreamReader reader = new(responseContent);
 
             while (await reader.ReadLineAsync(retryCancellationToken).ConfigureAwait(false) is { } line)
             {
@@ -380,12 +423,32 @@ internal sealed class PwnedPasswordsDownloader : AsyncCommand<PwnedPasswordsDown
         await ExecuteWithRetriesAsync(prefix, "downloading range file", maxRetries, async retryCancellationToken =>
         {
             using HttpResponseMessage response = await GetPwnedPasswordsRangeFromWeb(prefix, fetchNtlm, retryCancellationToken).ConfigureAwait(false);
+            byte[] expectedContentMd5 = GetContentMd5(response);
             await using Stream stream = await response.Content.ReadAsStreamAsync(retryCancellationToken).ConfigureAwait(false);
             using SafeFileHandle handle = File.OpenHandle(Path.Combine(outputDirectory, $"{prefix}.txt"), FileMode.Create, FileAccess.Write, FileShare.None, FileOptions.Asynchronous);
-            await handle.CopyFrom(stream, cancellationToken: retryCancellationToken).ConfigureAwait(false);
+            using IncrementalHash hash = IncrementalHash.CreateHash(HashAlgorithmName.MD5);
+            await handle.CopyFrom(stream, hash, cancellationToken: retryCancellationToken).ConfigureAwait(false);
+            ValidateContentMd5(expectedContentMd5, hash.GetHashAndReset());
         }, cancellationToken).ConfigureAwait(false);
 
         Interlocked.Increment(ref _statistics.HashesDownloaded);
+    }
+
+    private static byte[] GetContentMd5(HttpResponseMessage response) =>
+        response.Content.Headers.ContentMD5 ?? throw new InvalidDataException("Response did not contain a Content-MD5 header.");
+
+    private static void ValidateContentMd5(byte[] expectedHash, ReadOnlySpan<byte> content)
+    {
+        byte[] actualHash = MD5.HashData(content);
+        ValidateContentMd5(expectedHash, actualHash);
+    }
+
+    private static void ValidateContentMd5(byte[] expectedHash, byte[] actualHash)
+    {
+        if (!CryptographicOperations.FixedTimeEquals(expectedHash, actualHash))
+        {
+            throw new InvalidDataException("Response body did not match its Content-MD5 header.");
+        }
     }
 
     private static TimeSpan GetRetryDelay(int retryAttempt) => TimeSpan.FromSeconds(Math.Min(retryAttempt * s_retryDelay.TotalSeconds, s_maxRetryDelay.TotalSeconds));
@@ -445,24 +508,4 @@ internal sealed class PwnedPasswordsDownloader : AsyncCommand<PwnedPasswordsDown
         public string Prefix { get; }
         public byte[] Content { get; }
     }
-}
-
-public sealed class TypeRegistrar(IHostBuilder builder) : ITypeRegistrar
-{
-    public ITypeResolver Build() => new TypeResolver(builder.Build());
-
-    public void Register(Type service, Type implementation) => builder.ConfigureServices((_, services) => services.AddSingleton(service, implementation));
-    public void RegisterInstance(Type service, object implementation) => builder.ConfigureServices((_, services) => services.AddSingleton(service, implementation));
-    public void RegisterLazy(Type service, Func<object> func)
-    {
-        ArgumentNullException.ThrowIfNull(func);
-        builder.ConfigureServices((_, services) => services.AddSingleton(service, _ => func()));
-    }
-}
-
-public sealed class TypeResolver(IHost provider) : ITypeResolver, IDisposable
-{
-    private readonly IHost _host = provider ?? throw new ArgumentNullException(nameof(provider));
-    public object? Resolve(Type? type) => type != null ? _host.Services.GetService(type) : null;
-    public void Dispose() => _host.Dispose();
 }


### PR DESCRIPTION
This pull request modernizes the build, packaging, and codebase for the `HaveIBeenPwned.PwnedPasswords.Downloader` tool, focusing on .NET 10, Native AOT support, and improved multi-platform packaging. It also updates documentation and command-line usage for clarity and consistency.

**Build and Packaging Modernization:**

- **.NET 10 and Native AOT Support**
  - Updated the project to target only `net10.0` and enabled Native AOT publishing, trimming, and symbol stripping for smaller, faster executables. Added explicit runtime identifiers for Windows, Linux, and macOS platforms. [[1]](diffhunk://#diff-993f03528937f011ed08c8670b719596e2609c21b54498ff4d277f63ddcc426cL1-R4) [[2]](diffhunk://#diff-993f03528937f011ed08c8670b719596e2609c21b54498ff4d277f63ddcc426cL17-R39)
  - Updated package dependencies to .NET 10 compatible versions and replaced `Spectre.Console.Cli` with `System.CommandLine` and `Spectre.Console`.

- **CI/CD Workflow Overhaul**
  - Refactored GitHub Actions workflows to build, validate, and package Native AOT binaries per runtime identifier, as well as a framework-dependent fallback and tool pointer package. Workflows now use .NET 10 SDK and improved artifact handling. [[1]](diffhunk://#diff-68ba9d12f6f2601fe3c9f7f9d0d02aaea52384559d6d08fae7afc941663fdfcdL10-R135) [[2]](diffhunk://#diff-a0f3cb0ed47d35d09a2fe19a1782484412aafbc1aa357200c8674fed6d39d2deL8-R149)

**Codebase Improvements:**

- **Command-Line and Hosting Refactor**
  - Replaced the Spectre.Console CLI setup with `System.CommandLine` for argument parsing and command execution. Simplified host building and exception handling. [[1]](diffhunk://#diff-54048e192275f770b0ea4c4920e9df0abd46a73e694f485aa2340819f4537dc1L2-R6) [[2]](diffhunk://#diff-54048e192275f770b0ea4c4920e9df0abd46a73e694f485aa2340819f4537dc1L18-R35)
  - Enabled HTTP/3 connections in the downloader for improved performance.

- **Hash Calculation Integration**
  - Enhanced the file copy helper to optionally compute a hash while writing, supporting integrity checks or future features. [[1]](diffhunk://#diff-27effcdf8647cde18421ca818538238f60c319d6c3039070aef462e27fd0a0c7R6) [[2]](diffhunk://#diff-27effcdf8647cde18421ca818538238f60c319d6c3039070aef462e27fd0a0c7L34-R35) [[3]](diffhunk://#diff-27effcdf8647cde18421ca818538238f60c319d6c3039070aef462e27fd0a0c7R50)

**Documentation and Usage Updates:**

- **README and Parameter Clarification**
  - Updated installation instructions for .NET 10 and clarified platform support and runtime requirements.
  - Revised usage examples and parameter defaults for clarity, aligning with the new command-line interface and behavior (e.g., `--single` flag usage).